### PR TITLE
Bootstrap 4 Text Input Group Validation Div Placement

### DIFF
--- a/resources/views/bootstrap-4/form-input.blade.php
+++ b/resources/views/bootstrap-4/form-input.blade.php
@@ -33,11 +33,12 @@
                 </div>
             </div>
         @endisset
+
+        @if($hasErrorAndShow($name))
+            <x-form-errors :name="$name" />
+        @endif
     </div>
 
     {!! $help ?? null !!}
 
-    @if($hasErrorAndShow($name))
-        <x-form-errors :name="$name" />
-    @endif
 </div>


### PR DESCRIPTION
According to https://getbootstrap.com/docs/4.6/components/forms/#input-group-validation, the invalid-feedback div should be within the input-group.

![image](https://user-images.githubusercontent.com/1855836/132922948-4bda2b4c-dddd-4b34-a3d8-425bf0f03edd.png)
