### PR TITLE
Add missing .form-label classes in BS5 forms

### DIFF
--- a/resources/views/bootstrap-5/form-group.blade.php
+++ b/resources/views/bootstrap-5/form-group.blade.php
@@ -1,5 +1,5 @@
 <div {!! $attributes->merge(['class' => ($hasError($name) ? 'is-invalid' : '')]) !!}>
-    <x-form-label :label="$label" />
+    <x-form-label :label="$label" class="form-label" />
 
     <div class="@if($inline) d-flex flex-row flex-wrap inline-space @endif">
         {!! $slot !!}

--- a/resources/views/bootstrap-5/form-input-group.blade.php
+++ b/resources/views/bootstrap-5/form-input-group.blade.php
@@ -1,5 +1,5 @@
 <div class="mb-3">
-    <x-form-label :label="$label"></x-form-label>
+    <x-form-label :label="$label" class="form-label"></x-form-label>
 
     <div {!! $attributes->merge(['class' => 'input-group'  . ($hasError($name) ? ' is-invalid' : '')]) !!}>
         {!! $slot !!}

--- a/resources/views/bootstrap-5/form-input.blade.php
+++ b/resources/views/bootstrap-5/form-input.blade.php
@@ -2,7 +2,7 @@
 @if($floating) <div class="form-floating"> @endif
 
     @if(!$floating)
-        <x-form-label :label="$label" :for="$attributes->get('id') ?: $id()" />
+        <x-form-label :label="$label" :for="$attributes->get('id') ?: $id()" class="form-label" />
     @endif
 
     <input

--- a/resources/views/bootstrap-5/form-range.blade.php
+++ b/resources/views/bootstrap-5/form-range.blade.php
@@ -1,4 +1,4 @@
-<x-form-label :label="$label" :for="$attributes->get('id') ?: $id()" />
+<x-form-label :label="$label" :for="$attributes->get('id') ?: $id()" class="form-label" />
 
 <input
     {!! $attributes->merge(['class' => 'form-range' . ($hasError($name) ? ' is-invalid' : '')]) !!}

--- a/resources/views/bootstrap-5/form-select.blade.php
+++ b/resources/views/bootstrap-5/form-select.blade.php
@@ -1,7 +1,7 @@
 @if($floating) <div class="form-floating"> @endif
 
     @if(!$floating)
-        <x-form-label :label="$label" :for="$attributes->get('id') ?: $id()" />
+        <x-form-label :label="$label" :for="$attributes->get('id') ?: $id()" class="form-label" />
     @endif
 
     <select

--- a/resources/views/bootstrap-5/form-textarea.blade.php
+++ b/resources/views/bootstrap-5/form-textarea.blade.php
@@ -1,7 +1,7 @@
 @if($floating) <div class="form-floating"> @endif
 
     @if(!$floating)
-        <x-form-label :label="$label" :for="$attributes->get('id') ?: $id()" />
+        <x-form-label :label="$label" :for="$attributes->get('id') ?: $id()" class="form-label" />
     @endif
 
     <textarea


### PR DESCRIPTION
According to [BS5 docs](https://getbootstrap.com/docs/5.2/forms/form-control/#example), form labels should contain .form-label class to be displayed correctly. Without it, the space between label and field is too small.

Before:
![obraz](https://user-images.githubusercontent.com/106807592/171835143-10e1a6b1-7421-40bd-a3f9-c2d1db3426e5.png)

After:
![obraz](https://user-images.githubusercontent.com/106807592/171835192-465fdeaf-6449-4c70-9ba3-514274130e75.png)
