### PR TITLE
Output sub-item form-errors messages when they exist

### DIFF
--- a/resources/views/bootstrap-4/form-errors.blade.php
+++ b/resources/views/bootstrap-4/form-errors.blade.php
@@ -3,3 +3,6 @@
         {{ $message }}
     </div>
 @enderror
+@foreach(collect($errors->get($name.'.*')) as $message)
+    <x-form-errors name="{{ $name }}.*" :bag="$bag" />
+@endforeach

--- a/resources/views/bootstrap-5/form-errors.blade.php
+++ b/resources/views/bootstrap-5/form-errors.blade.php
@@ -3,3 +3,6 @@
         {{ $message }}
     </div>
 @enderror
+@foreach(collect($errors->get($name.'.*')) as $message)
+    <x-form-errors name="{{ $name }}.*" :bag="$bag" />
+@endforeach

--- a/resources/views/tailwind-2/form-errors.blade.php
+++ b/resources/views/tailwind-2/form-errors.blade.php
@@ -3,3 +3,6 @@
         {{ $message }}
     </p>
 @enderror
+@foreach(collect($errors->get($name.'.*')) as $message)
+    <x-form-errors name="{{ $name }}.*" :bag="$bag" />
+@endforeach

--- a/resources/views/tailwind-forms-simple/form-errors.blade.php
+++ b/resources/views/tailwind-forms-simple/form-errors.blade.php
@@ -3,3 +3,6 @@
         {{ $message }}
     </p>
 @enderror
+@foreach(collect($errors->get($name.'.*')) as $message)
+    <x-form-errors name="{{ $name }}.*" :bag="$bag" />
+@endforeach

--- a/resources/views/tailwind/form-errors.blade.php
+++ b/resources/views/tailwind/form-errors.blade.php
@@ -3,3 +3,6 @@
         {{ $message }}
     </p>
 @enderror
+@foreach(collect($errors->get($name.'.*')) as $message)
+    <x-form-errors name="{{ $name }}.*" :bag="$bag" />
+@endforeach


### PR DESCRIPTION
When validating an array Laravel [lets us validate array items](https://laravel.com/docs/9.x/validation#retrieving-all-error-messages-for-a-field) using the `fieldname.*` syntax which can result in the error bag containing messages which are returned as `fieldname.<array_index>`.

These are not output at the moment, this PR is a simple fix to (recursively) output them if they exist.

I've just extended the `<x-form-errors>` component to output them as their own messages, an enhancement might be to make them smarter or display in a more inline way..

There were no existing tests for form-errors, so apologies for not adding one and starting those.

